### PR TITLE
Step4 -- Fixing the Alignment for GetCity component

### DIFF
--- a/app/components/GetCity.js
+++ b/app/components/GetCity.js
@@ -30,7 +30,7 @@ function getStyles (props) {
     justifyContent: 'center',
     alignItems: 'center',
     maxWidth: 300,
-    alignSelf: 'right'
+    alignSelf: props.alignself || 'right'
   }
 }
 
@@ -50,6 +50,7 @@ function GetCity (props) {
 
 GetCity.propTypes = {
   direction: PropTypes.string,
+  alignself: PropTypes.string,
   onSubmitCity: PropTypes.func.isRequired,
   onUpdateCity: PropTypes.func.isRequired,
   city: PropTypes.string.isRequired

--- a/app/components/GetCity.js
+++ b/app/components/GetCity.js
@@ -30,7 +30,7 @@ function getStyles (props) {
     justifyContent: 'center',
     alignItems: 'center',
     maxWidth: 300,
-    alignSelf: props.alignself || 'right'
+    alignSelf: props.alignself || 'center'
   }
 }
 

--- a/app/containers/GetCityContainer.js
+++ b/app/containers/GetCityContainer.js
@@ -30,7 +30,7 @@ var GetCityContainer = React.createClass({
     return (
       <GetCity
         direction={this.props.direction}
-        alignself:{this.props.alignself}
+        alignself={this.props.alignself}
         onSubmitCity={this.handleSubmitCity}
         onUpdateCity={this.handleUpdateCity}
         city={this.state.city} />

--- a/app/containers/GetCityContainer.js
+++ b/app/containers/GetCityContainer.js
@@ -5,11 +5,13 @@ var GetCity = require('../components/GetCity');
 var GetCityContainer = React.createClass({
   getDefaultProps: function () {
     return {
-      direction: 'column'
+      direction: 'column',
+      alignself: 'center'
     }
   },
   propTypes: {
-    direction: PropTypes.string
+    direction: PropTypes.string,
+    alignself: PropTypes.string
   },
   getInitialState: function () {
     return {
@@ -28,6 +30,7 @@ var GetCityContainer = React.createClass({
     return (
       <GetCity
         direction={this.props.direction}
+        alignself:{this.props.alignself}
         onSubmitCity={this.handleSubmitCity}
         onUpdateCity={this.handleUpdateCity}
         city={this.state.city} />

--- a/app/containers/Main.js
+++ b/app/containers/Main.js
@@ -22,7 +22,9 @@ var Main = React.createClass({
       <div style={styles.container}>
         <div style={styles.header}>
           <h2 style={{margin: 0}}>Clever Title</h2>
-          <GetCityContainer direction='row' />
+          <GetCityContainer 
+            direction='row'
+            alignself='right' />
         </div>
         {this.props.children}
       </div>


### PR DESCRIPTION
The GetCity component uses `alignSelf: 'right'` in the function **getStyles** that is on charge of retrieving the styles for the **GetCity** div container. That makes this component to be aligned on the right instead of at the center inside the **HomeContainer**.

In order to allow the component to adapt its alignment dynamically based on where are we using it, we have added the `alignSelf: props.alignself || 'center'` that will by default align it into the center unless told something else through the prop **alignself** passed through the **GetCityContainer** (e.g: we align it to the right when including **GetCityContainer** in the header)